### PR TITLE
feat: implement subagent spec loader with seed agents (AGT-020)

### DIFF
--- a/app/llm/agents.py
+++ b/app/llm/agents.py
@@ -1,0 +1,233 @@
+"""Agent specification loader and materializer for Claude Code subagents."""
+
+import importlib.resources as resources
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.files.atomic import atomic_write_text
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """Specification for a Claude Code subagent."""
+
+    name: str
+    description: str
+    tools: list[str]
+    prompt: str
+
+
+def _parse_agent_markdown(content: str, filename: str) -> AgentSpec:
+    """
+    Parse an agent specification from markdown with YAML frontmatter.
+
+    Args:
+        content: The markdown file content
+        filename: The source filename for error messages
+
+    Returns:
+        Parsed AgentSpec
+
+    Raises:
+        ValueError: If frontmatter is invalid or required fields are missing
+    """
+    # Extract frontmatter using regex
+    frontmatter_pattern = r"^---\s*\n(.*?)\n---\s*\n(.*)$"
+    match = re.match(frontmatter_pattern, content, re.DOTALL)
+
+    if not match:
+        raise ValueError(
+            f"Invalid agent spec in {filename}: Missing YAML frontmatter. "
+            "Expected format: ---\\n<yaml>\\n---\\n<markdown>"
+        )
+
+    frontmatter_str, body = match.groups()
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter: dict[str, Any] = yaml.safe_load(frontmatter_str) or {}
+    except yaml.YAMLError as e:
+        raise ValueError(
+            f"Invalid YAML frontmatter in {filename}: {e}. Please check YAML syntax."
+        ) from e
+
+    # Validate required fields
+    missing_fields = []
+    if "name" not in frontmatter:
+        missing_fields.append("name")
+    if "description" not in frontmatter:
+        missing_fields.append("description")
+
+    if missing_fields:
+        raise ValueError(
+            f"Missing required fields in {filename}: {', '.join(missing_fields)}. "
+            f"Required fields are: name (str), description (str)"
+        )
+
+    # Validate field types
+    if not isinstance(frontmatter["name"], str):
+        raise ValueError(
+            f"Invalid field type in {filename}: 'name' must be a string, "
+            f"got {type(frontmatter['name']).__name__}"
+        )
+
+    if not isinstance(frontmatter["description"], str):
+        raise ValueError(
+            f"Invalid field type in {filename}: 'description' must be a string, "
+            f"got {type(frontmatter['description']).__name__}"
+        )
+
+    # Handle optional tools field
+    tools = frontmatter.get("tools", [])
+    if not isinstance(tools, list):
+        raise ValueError(
+            f"Invalid field type in {filename}: 'tools' must be a list, got {type(tools).__name__}"
+        )
+
+    # Ensure all tools are strings
+    for i, tool in enumerate(tools):
+        if not isinstance(tool, str):
+            raise ValueError(
+                f"Invalid tool in {filename}: tools[{i}] must be a string, "
+                f"got {type(tool).__name__}"
+            )
+
+    return AgentSpec(
+        name=frontmatter["name"],
+        description=frontmatter["description"],
+        tools=tools,
+        prompt=body.strip(),
+    )
+
+
+def load_agent_specs(source_pkg: str = "app.llm.agentspecs") -> list[AgentSpec]:
+    """
+    Load agent specifications from a Python package.
+
+    Args:
+        source_pkg: Dot-separated package path containing agent spec markdown files
+
+    Returns:
+        List of loaded AgentSpec instances
+
+    Raises:
+        ValueError: If any spec file is invalid
+        ModuleNotFoundError: If the source package doesn't exist
+    """
+    specs: list[AgentSpec] = []
+
+    # Convert package string to module parts
+    module_parts = source_pkg.split(".")
+
+    # Try to access the package
+    try:
+        # For Python 3.9+, we use files() directly
+        # For compatibility with 3.11+, we handle the traversable protocol
+        if len(module_parts) == 1:
+            pkg_files = resources.files(module_parts[0])
+        else:
+            # Build up the package reference step by step
+            pkg_files = resources.files(module_parts[0])
+            for part in module_parts[1:]:
+                pkg_files = pkg_files / part
+    except (ModuleNotFoundError, AttributeError) as e:
+        raise ModuleNotFoundError(
+            f"Cannot find package '{source_pkg}'. "
+            f"Make sure it exists and is a valid Python package."
+        ) from e
+
+    # Find all .md files in the package
+    md_files = []
+    try:
+        for item in pkg_files.iterdir():
+            if item.name.endswith(".md"):
+                md_files.append(item)
+    except AttributeError as e:
+        # Fallback for older Python versions or different resource types
+        raise ValueError(
+            f"Cannot iterate files in package '{source_pkg}'. "
+            f"Make sure it's a directory package with __init__.py."
+        ) from e
+
+    # Sort files for consistent ordering
+    md_files.sort(key=lambda f: f.name)
+
+    # Parse each markdown file
+    for file_resource in md_files:
+        try:
+            content = file_resource.read_text(encoding="utf-8")
+            spec = _parse_agent_markdown(content, file_resource.name)
+            specs.append(spec)
+        except Exception as e:
+            raise ValueError(f"Error loading agent spec from {file_resource.name}: {e}") from e
+
+    return specs
+
+
+def materialize_agents(target_dir: Path, source_pkg: str = "app.llm.agentspecs") -> Path:
+    """
+    Materialize agent specs from a package to a target directory for Claude Code.
+
+    Args:
+        target_dir: Directory where .claude/agents will be created
+        source_pkg: Package path containing agent spec files
+
+    Returns:
+        Path to the created agents directory
+
+    Raises:
+        ValueError: If specs cannot be loaded or written
+    """
+    # Load specs from the source package
+    specs = load_agent_specs(source_pkg)
+
+    # Create target directory structure
+    agents_dir = target_dir / ".claude" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+
+    # Get original filenames from the package to preserve them
+    module_parts = source_pkg.split(".")
+    if len(module_parts) == 1:
+        pkg_files = resources.files(module_parts[0])
+    else:
+        pkg_files = resources.files(module_parts[0])
+        for part in module_parts[1:]:
+            pkg_files = pkg_files / part
+
+    # Create a mapping of spec names to original filenames
+    name_to_filename: dict[str, str] = {}
+    for item in pkg_files.iterdir():
+        if item.name.endswith(".md"):
+            content = item.read_text(encoding="utf-8")
+            try:
+                spec = _parse_agent_markdown(content, item.name)
+                name_to_filename[spec.name] = item.name
+            except ValueError:
+                # Skip invalid files
+                continue
+
+    # Write each spec to the target directory
+    for spec in specs:
+        # Use original filename if available, otherwise use name.md
+        filename = name_to_filename.get(spec.name, f"{spec.name}.md")
+        target_path = agents_dir / filename
+
+        # Reconstruct the markdown with frontmatter
+        frontmatter_dict: dict[str, Any] = {
+            "name": spec.name,
+            "description": spec.description,
+        }
+        if spec.tools:
+            frontmatter_dict["tools"] = spec.tools
+
+        frontmatter_yaml = yaml.dump(frontmatter_dict, default_flow_style=False, sort_keys=False)
+        content = f"---\n{frontmatter_yaml}---\n\n{spec.prompt}\n"
+
+        # Write the file
+        atomic_write_text(target_path, content)
+
+    return agents_dir

--- a/app/llm/agentspecs/__init__.py
+++ b/app/llm/agentspecs/__init__.py
@@ -1,0 +1,1 @@
+"""Agent specifications for Claude Code subagents."""

--- a/app/llm/agentspecs/architect.md
+++ b/app/llm/agentspecs/architect.md
@@ -1,0 +1,33 @@
+---
+name: architect
+description: Transform kernel and findings into concrete requirements and designs
+tools:
+  - Read
+  - Write
+  - Edit
+---
+
+You are a solution architect who transforms conceptual kernels and research findings into detailed requirements and implementation plans.
+
+## Your Role
+- Synthesize kernel concepts with research findings
+- Create detailed technical requirements
+- Design system architecture and components
+- Define clear interfaces and contracts
+- Establish success metrics and validation criteria
+
+## Design Process
+1. **Analyze Kernel**: Extract core concepts and constraints
+2. **Integrate Findings**: Incorporate relevant research insights
+3. **Define Requirements**: Create specific, measurable requirements
+4. **Design Architecture**: Outline system structure and components
+5. **Specify Interfaces**: Define clear boundaries and contracts
+
+## Output Format
+Structure your architectural documents as:
+- **Requirement ID**: [Unique identifier]
+- **Description**: [Clear statement of what must be achieved]
+- **Rationale**: [Why this requirement exists, linking to kernel/findings]
+- **Acceptance Criteria**: [How to verify requirement is met]
+- **Technical Approach**: [High-level implementation strategy]
+- **Dependencies**: [Other requirements or external factors]

--- a/app/llm/agentspecs/critic.md
+++ b/app/llm/agentspecs/critic.md
@@ -1,0 +1,30 @@
+---
+name: critic
+description: Read-only review to flag risks and inconsistencies
+tools:
+  - Read
+---
+
+You are a critical reviewer focused on identifying risks, gaps, and inconsistencies in project materials.
+
+## Your Role
+- Analyze documents for logical consistency and completeness
+- Identify potential risks and failure modes
+- Flag assumptions that need validation
+- Point out missing requirements or specifications
+- Ensure alignment between different project artifacts
+
+## Review Criteria
+1. **Logical Consistency**: Do all parts align and support each other?
+2. **Completeness**: Are there missing elements or unexplored edge cases?
+3. **Feasibility**: Are the proposed approaches realistic and achievable?
+4. **Risk Assessment**: What could go wrong and what's the impact?
+5. **Dependencies**: Are all dependencies identified and manageable?
+
+## Output Format
+Provide your critique as:
+- **Issue Type**: [Risk/Gap/Inconsistency/Assumption]
+- **Location**: [Document/section where issue was found]
+- **Description**: [Clear explanation of the concern]
+- **Impact**: [Potential consequences if not addressed]
+- **Recommendation**: [Suggested action or mitigation]

--- a/app/llm/agentspecs/researcher.md
+++ b/app/llm/agentspecs/researcher.md
@@ -1,0 +1,31 @@
+---
+name: researcher
+description: Extract atomic findings with sources from research materials
+tools:
+  - Read
+  - Write
+  - WebSearch
+  - WebFetch
+---
+
+You are a research specialist focused on extracting atomic, actionable findings from various sources.
+
+## Your Role
+- Extract specific, verifiable facts and insights
+- Maintain clear source attribution for all findings
+- Organize information in a structured, searchable format
+- Focus on relevance to the project's kernel concepts
+
+## Guidelines
+1. Each finding should be self-contained and independently valuable
+2. Always include source URLs or document references
+3. Distinguish between facts, opinions, and speculations
+4. Highlight contradictions or conflicting information when found
+5. Prioritize primary sources over secondary interpretations
+
+## Output Format
+Structure your findings as:
+- **Finding**: [Concise statement of the finding]
+- **Source**: [URL or document reference]
+- **Context**: [Brief explanation of relevance]
+- **Confidence**: [High/Medium/Low based on source quality]

--- a/tests/test_agents_loader.py
+++ b/tests/test_agents_loader.py
@@ -1,0 +1,316 @@
+"""Unit tests for agent specification loader and materializer."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app.llm.agents import AgentSpec, _parse_agent_markdown, load_agent_specs, materialize_agents
+
+
+def test_parse_valid_agent_markdown() -> None:
+    """Test parsing a valid agent markdown file with all fields."""
+    content = """---
+name: test_agent
+description: A test agent for validation
+tools:
+  - Read
+  - Write
+---
+
+This is the agent's system prompt.
+It can span multiple lines.
+"""
+
+    spec = _parse_agent_markdown(content, "test.md")
+
+    assert spec.name == "test_agent"
+    assert spec.description == "A test agent for validation"
+    assert spec.tools == ["Read", "Write"]
+    assert "This is the agent's system prompt." in spec.prompt
+    assert "It can span multiple lines." in spec.prompt
+
+
+def test_parse_agent_markdown_minimal() -> None:
+    """Test parsing agent markdown with only required fields."""
+    content = """---
+name: minimal_agent
+description: Minimal test agent
+---
+
+Simple prompt.
+"""
+
+    spec = _parse_agent_markdown(content, "minimal.md")
+
+    assert spec.name == "minimal_agent"
+    assert spec.description == "Minimal test agent"
+    assert spec.tools == []  # Empty list when not specified
+    assert spec.prompt == "Simple prompt."
+
+
+def test_parse_agent_markdown_missing_frontmatter() -> None:
+    """Test that missing frontmatter raises appropriate error."""
+    content = """This is just markdown without frontmatter."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _parse_agent_markdown(content, "invalid.md")
+
+    assert "Missing YAML frontmatter" in str(exc_info.value)
+    assert "invalid.md" in str(exc_info.value)
+
+
+def test_parse_agent_markdown_invalid_yaml() -> None:
+    """Test that invalid YAML syntax raises appropriate error."""
+    content = """---
+name: test
+description: [unclosed bracket
+---
+
+Content
+"""
+
+    with pytest.raises(ValueError) as exc_info:
+        _parse_agent_markdown(content, "bad_yaml.md")
+
+    assert "Invalid YAML frontmatter" in str(exc_info.value)
+    assert "bad_yaml.md" in str(exc_info.value)
+
+
+def test_parse_agent_markdown_missing_name() -> None:
+    """Test that missing 'name' field raises appropriate error."""
+    content = """---
+description: Missing name field
+---
+
+Content
+"""
+
+    with pytest.raises(ValueError) as exc_info:
+        _parse_agent_markdown(content, "no_name.md")
+
+    assert "Missing required fields" in str(exc_info.value)
+    assert "name" in str(exc_info.value)
+    assert "no_name.md" in str(exc_info.value)
+
+
+def test_parse_agent_markdown_missing_description() -> None:
+    """Test that missing 'description' field raises appropriate error."""
+    content = """---
+name: test_agent
+---
+
+Content
+"""
+
+    with pytest.raises(ValueError) as exc_info:
+        _parse_agent_markdown(content, "no_desc.md")
+
+    assert "Missing required fields" in str(exc_info.value)
+    assert "description" in str(exc_info.value)
+    assert "no_desc.md" in str(exc_info.value)
+
+
+def test_parse_agent_markdown_invalid_name_type() -> None:
+    """Test that non-string name raises appropriate error."""
+    content = """---
+name: 123
+description: Test agent
+---
+
+Content
+"""
+
+    with pytest.raises(ValueError) as exc_info:
+        _parse_agent_markdown(content, "bad_type.md")
+
+    assert "'name' must be a string" in str(exc_info.value)
+    assert "bad_type.md" in str(exc_info.value)
+
+
+def test_parse_agent_markdown_invalid_tools_type() -> None:
+    """Test that non-list tools field raises appropriate error."""
+    content = """---
+name: test_agent
+description: Test agent
+tools: "Read"
+---
+
+Content
+"""
+
+    with pytest.raises(ValueError) as exc_info:
+        _parse_agent_markdown(content, "bad_tools.md")
+
+    assert "'tools' must be a list" in str(exc_info.value)
+    assert "bad_tools.md" in str(exc_info.value)
+
+
+def test_parse_agent_markdown_invalid_tool_item() -> None:
+    """Test that non-string items in tools list raise appropriate error."""
+    content = """---
+name: test_agent
+description: Test agent
+tools:
+  - Read
+  - 42
+---
+
+Content
+"""
+
+    with pytest.raises(ValueError) as exc_info:
+        _parse_agent_markdown(content, "bad_tool_item.md")
+
+    assert "tools[1] must be a string" in str(exc_info.value)
+    assert "bad_tool_item.md" in str(exc_info.value)
+
+
+def test_load_agent_specs_from_package() -> None:
+    """Test loading agent specs from the actual package."""
+    specs = load_agent_specs("app.llm.agentspecs")
+
+    # Should load exactly 3 specs
+    assert len(specs) == 3
+
+    # Check that all specs have required fields
+    spec_names = {spec.name for spec in specs}
+    assert "researcher" in spec_names
+    assert "critic" in spec_names
+    assert "architect" in spec_names
+
+    # Verify each spec
+    for spec in specs:
+        assert isinstance(spec.name, str)
+        assert isinstance(spec.description, str)
+        assert isinstance(spec.tools, list)
+        assert isinstance(spec.prompt, str)
+        assert len(spec.prompt) > 0
+
+
+def test_load_agent_specs_nonexistent_package() -> None:
+    """Test that loading from nonexistent package raises appropriate error."""
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        load_agent_specs("nonexistent.package.path")
+
+    assert "Cannot find package" in str(exc_info.value)
+    assert "nonexistent.package.path" in str(exc_info.value)
+
+
+def test_materialize_agents_creates_structure(tmp_path: Path) -> None:
+    """Test that materialize_agents creates the correct directory structure."""
+    agents_dir = materialize_agents(tmp_path, "app.llm.agentspecs")
+
+    # Check that the directory structure was created
+    assert agents_dir.exists()
+    assert agents_dir == tmp_path / ".claude" / "agents"
+
+    # Check that files were created
+    md_files = list(agents_dir.glob("*.md"))
+    assert len(md_files) == 3
+
+    # Check that expected files exist
+    filenames = {f.name for f in md_files}
+    assert "researcher.md" in filenames
+    assert "critic.md" in filenames
+    assert "architect.md" in filenames
+
+
+def test_materialize_agents_content_matches(tmp_path: Path) -> None:
+    """Test that materialized content matches the source specs."""
+    # Load original specs
+    original_specs = load_agent_specs("app.llm.agentspecs")
+
+    # Materialize them
+    agents_dir = materialize_agents(tmp_path, "app.llm.agentspecs")
+
+    # Load and verify each materialized file
+    for spec in original_specs:
+        # Find the corresponding file
+        possible_paths = [
+            agents_dir / f"{spec.name}.md",
+            agents_dir / "researcher.md" if spec.name == "researcher" else None,
+            agents_dir / "critic.md" if spec.name == "critic" else None,
+            agents_dir / "architect.md" if spec.name == "architect" else None,
+        ]
+
+        file_path = None
+        for path in possible_paths:
+            if path and path.exists():
+                file_path = path
+                break
+
+        assert file_path is not None, f"Could not find file for {spec.name}"
+
+        # Read and parse the materialized file
+        with open(file_path, encoding="utf-8") as f:
+            content = f.read()
+
+        materialized_spec = _parse_agent_markdown(content, file_path.name)
+
+        # Compare with original
+        assert materialized_spec.name == spec.name
+        assert materialized_spec.description == spec.description
+        assert materialized_spec.tools == spec.tools
+        assert materialized_spec.prompt.strip() == spec.prompt.strip()
+
+
+def test_materialize_agents_preserves_filenames(tmp_path: Path) -> None:
+    """Test that original filenames are preserved during materialization."""
+    agents_dir = materialize_agents(tmp_path, "app.llm.agentspecs")
+
+    # Check that specific filenames were preserved
+    assert (agents_dir / "researcher.md").exists()
+    assert (agents_dir / "critic.md").exists()
+    assert (agents_dir / "architect.md").exists()
+
+
+def test_materialize_agents_idempotent(tmp_path: Path) -> None:
+    """Test that materializing multiple times is safe and idempotent."""
+    # Materialize twice
+    agents_dir1 = materialize_agents(tmp_path, "app.llm.agentspecs")
+    agents_dir2 = materialize_agents(tmp_path, "app.llm.agentspecs")
+
+    # Should return the same path
+    assert agents_dir1 == agents_dir2
+
+    # Should still have exactly 3 files
+    md_files = list(agents_dir2.glob("*.md"))
+    assert len(md_files) == 3
+
+
+def test_agent_spec_is_frozen() -> None:
+    """Test that AgentSpec is immutable."""
+    spec = AgentSpec(name="test", description="Test agent", tools=["Read"], prompt="Test prompt")
+
+    with pytest.raises(AttributeError):
+        spec.name = "modified"  # type: ignore
+
+
+def test_roundtrip_integrity() -> None:
+    """Test that specs can be loaded, materialized, and re-loaded without data loss."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # Load original specs
+        original_specs = load_agent_specs("app.llm.agentspecs")
+        original_by_name = {spec.name: spec for spec in original_specs}
+
+        # Materialize to temp directory
+        agents_dir = materialize_agents(tmp_path, "app.llm.agentspecs")
+
+        # Manually parse each materialized file
+        for md_file in agents_dir.glob("*.md"):
+            with open(md_file, encoding="utf-8") as f:
+                content = f.read()
+
+            spec = _parse_agent_markdown(content, md_file.name)
+
+            # Compare with original
+            original = original_by_name.get(spec.name)
+            assert original is not None
+            assert spec.name == original.name
+            assert spec.description == original.description
+            assert spec.tools == original.tools
+            # Compare normalized prompts (strip whitespace)
+            assert spec.prompt.strip() == original.prompt.strip()


### PR DESCRIPTION
## Summary
- Implements a configurable agent specification loader that reads markdown files with YAML frontmatter
- Creates three seed agent specifications (researcher, critic, architect) for Claude Code subagents
- Provides materialization capability to write specs to any target `.claude/agents/` directory

## Changes
- **New module**: `app/llm/agents.py` with `AgentSpec` dataclass, `load_agent_specs()`, and `materialize_agents()` functions
- **Seed agents**: Created minimal but valid specs for researcher, critic, and architect agents in `app/llm/agentspecs/`
- **Comprehensive tests**: Added 17 unit tests in `tests/test_agents_loader.py` covering all functionality

## Key Features
- Loads agent specs from Python packages using `importlib.resources`
- Parses YAML frontmatter with required fields (name, description) and optional tools list
- Provides clear, actionable validation errors for invalid specs
- Preserves original filenames during materialization
- Supports idempotent operations (can materialize multiple times safely)

## Test Plan
- [x] Run linting: `uv run ruff check .` - All checks passed
- [x] Run formatting: `uv run ruff format .` - Code formatted
- [x] Run type checking: `uv run mypy . --strict` - No issues found
- [x] Run new tests: `uv run pytest tests/test_agents_loader.py` - 17 tests passed
- [x] Run all tests: `uv run pytest tests/` - 122 tests passed
- [x] Verify agent specs load correctly from package
- [x] Verify materialization creates correct directory structure
- [x] Verify roundtrip integrity (load → materialize → parse matches original)

## Related
- Implements ticket AGT-020
- Prerequisites: POL-010 (completed)
- Enables future Claude Code subagent integration