### PR TITLE
feat: implement agent invocation and policy merge (AGT-021)

### DIFF
--- a/app/tui/widgets/agent_selector.py
+++ b/app/tui/widgets/agent_selector.py
@@ -1,0 +1,221 @@
+"""Agent selection widget for choosing Claude Code agents."""
+
+from textual import events, on
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Static
+
+from app.llm.agents import AgentSpec
+
+
+class AgentCard(Container):
+    """Display card for a single agent."""
+
+    def __init__(self, agent: AgentSpec, selected: bool = False) -> None:
+        """
+        Initialize the agent card.
+
+        Args:
+            agent: The agent specification to display
+            selected: Whether this agent is currently selected
+        """
+        super().__init__(classes="agent-card")
+        self.agent = agent
+        self.selected = selected
+        if selected:
+            self.add_class("selected")
+
+    def compose(self) -> ComposeResult:
+        """Create the card content."""
+        yield Label(f"[bold]{self.agent.name}[/bold]", classes="agent-name")
+        yield Label(self.agent.description, classes="agent-description")
+        if self.agent.tools:
+            tools_str = ", ".join(self.agent.tools)
+            yield Label(f"[dim]Tools: {tools_str}[/dim]", classes="agent-tools")
+        else:
+            yield Label("[dim]Tools: None[/dim]", classes="agent-tools")
+
+
+class AgentSelector(ModalScreen[AgentSpec | None]):
+    """Modal for selecting an agent for a session."""
+
+    DEFAULT_CSS = """
+    AgentSelector {
+        align: center middle;
+    }
+
+    AgentSelector > Container {
+        width: 80;
+        height: auto;
+        max-height: 80%;
+        border: thick $background 80%;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    .modal-title {
+        text-align: center;
+        width: 100%;
+        margin-bottom: 1;
+    }
+
+    .agent-list {
+        height: auto;
+        max-height: 20;
+        margin-bottom: 1;
+    }
+
+    .agent-card {
+        padding: 1;
+        margin-bottom: 1;
+        border: solid $primary 50%;
+    }
+
+    .agent-card.selected {
+        border: solid $accent;
+        background: $boost;
+    }
+
+    .agent-card:hover {
+        background: $boost;
+    }
+
+    .agent-name {
+        margin-bottom: 0;
+    }
+
+    .agent-description {
+        margin-bottom: 0;
+    }
+
+    .agent-tools {
+        margin-top: 0;
+    }
+
+    .final-tools {
+        border: solid $primary 50%;
+        padding: 1;
+        margin-bottom: 1;
+    }
+
+    .button-row {
+        dock: bottom;
+        align: center middle;
+        padding: 1 0;
+    }
+
+    .button-row Button {
+        margin: 0 1;
+    }
+    """
+
+    def __init__(
+        self,
+        agents: list[AgentSpec],
+        stage_allowed: list[str],
+        stage_denied: list[str],
+    ) -> None:
+        """
+        Initialize the agent selector.
+
+        Args:
+            agents: List of available agents
+            stage_allowed: Tools allowed by the current stage
+            stage_denied: Tools denied by the current stage
+        """
+        super().__init__()
+        self.agents = agents
+        self.stage_allowed = stage_allowed
+        self.stage_denied = stage_denied
+        self.selected_agent: AgentSpec | None = None
+        self.agent_cards: list[AgentCard] = []
+
+    def compose(self) -> ComposeResult:
+        """Create the selector UI."""
+        with Container():
+            yield Static("[bold]Select Agent (Optional)[/bold]", classes="modal-title")
+            yield Static(
+                "[dim]Choose an agent to assist with this session, or continue without one.[/dim]",
+                classes="modal-subtitle",
+            )
+
+            # Agent list
+            with VerticalScroll(classes="agent-list"):
+                for agent in self.agents:
+                    card = AgentCard(agent, selected=False)
+                    self.agent_cards.append(card)
+                    yield card
+
+            # Final tools preview
+            yield Container(
+                Static("[bold]Final Tool Permissions:[/bold]"),
+                Static(self._compute_final_tools_text(), id="final-tools-text"),
+                classes="final-tools",
+            )
+
+            # Buttons
+            with Horizontal(classes="button-row"):
+                yield Button("Select", variant="primary", id="select-button")
+                yield Button("No Agent", variant="default", id="no-agent-button")
+                yield Button("Cancel", variant="default", id="cancel-button")
+
+    def _compute_final_tools_text(self) -> str:
+        """Compute the final tools text based on current selection."""
+        if self.selected_agent and self.selected_agent.tools:
+            # Intersection of stage allowed and agent tools
+            allowed = set(self.stage_allowed).intersection(set(self.selected_agent.tools))
+        else:
+            # Just stage allowed
+            allowed = set(self.stage_allowed)
+
+        # Remove denied tools
+        final = allowed - set(self.stage_denied)
+
+        if final:
+            return f"[green]{', '.join(sorted(final))}[/green]"
+        else:
+            return "[red]None (no tools available)[/red]"
+
+    def on_click(self, event: events.Click) -> None:
+        """Handle clicks on agent cards."""
+        # Check if click was on an agent card
+        if event.widget is None:
+            return
+
+        for card in self.agent_cards:
+            if card in event.widget.ancestors_with_self:
+                # Deselect all cards
+                for c in self.agent_cards:
+                    c.remove_class("selected")
+                    c.selected = False
+
+                # Select the clicked card
+                card.add_class("selected")
+                card.selected = True
+                self.selected_agent = card.agent
+
+                # Update final tools preview
+                tools_text = self.query_one("#final-tools-text", Static)
+                tools_text.update(self._compute_final_tools_text())
+                break
+
+    @on(Button.Pressed, "#select-button")
+    def handle_select(self) -> None:
+        """Handle select button - return selected agent."""
+        if self.selected_agent:
+            self.dismiss(self.selected_agent)
+        else:
+            # No agent selected, treat as "No Agent"
+            self.dismiss(None)
+
+    @on(Button.Pressed, "#no-agent-button")
+    def handle_no_agent(self) -> None:
+        """Handle no agent button - return None."""
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#cancel-button")
+    def handle_cancel(self) -> None:
+        """Handle cancel button - dismiss with None (cancellation)."""
+        # In this context, we'll treat cancel as "no agent" to avoid blocking
+        self.dismiss(None)

--- a/tests/test_policy_merge.py
+++ b/tests/test_policy_merge.py
@@ -1,0 +1,242 @@
+"""Tests for policy merge functionality."""
+
+from pathlib import Path
+
+import pytest
+
+from app.llm.agents import AgentSpec
+from app.llm.sessions import SessionPolicy, get_policy, merge_agent_policy
+
+
+@pytest.fixture
+def base_policy() -> SessionPolicy:
+    """Create a base policy for testing."""
+    return SessionPolicy(
+        stage="test",
+        system_prompt_path=Path("/tmp/test.md"),
+        allowed_tools=["Read", "Write", "Edit"],
+        denied_tools=["Bash", "WebSearch"],
+        write_roots=["projects/**"],
+        permission_mode="restricted",
+        web_tools_allowed=["WebFetch"],
+    )
+
+
+@pytest.fixture
+def agent_with_tools() -> AgentSpec:
+    """Create an agent spec with tools."""
+    return AgentSpec(
+        name="test-agent",
+        description="A test agent",
+        tools=["Read", "Edit", "WebFetch", "Bash"],
+        prompt="Test prompt",
+    )
+
+
+@pytest.fixture
+def agent_without_tools() -> AgentSpec:
+    """Create an agent spec without tools."""
+    return AgentSpec(
+        name="empty-agent",
+        description="An agent with no tools",
+        tools=[],
+        prompt="Test prompt",
+    )
+
+
+def test_merge_with_no_agent(base_policy: SessionPolicy) -> None:
+    """Test merging with no agent (None) returns base policy tools."""
+    result = merge_agent_policy(base_policy, None)
+
+    assert result.stage == base_policy.stage
+    assert result.system_prompt_path == base_policy.system_prompt_path
+    assert set(result.allowed_tools) == {"Read", "Write", "Edit"}
+    assert result.denied_tools == base_policy.denied_tools
+    assert result.write_roots == base_policy.write_roots
+    assert result.permission_mode == base_policy.permission_mode
+
+
+def test_merge_with_empty_agent_tools(
+    base_policy: SessionPolicy, agent_without_tools: AgentSpec
+) -> None:
+    """Test merging with agent that has empty tools list."""
+    result = merge_agent_policy(base_policy, agent_without_tools)
+
+    # Empty agent tools means no tools allowed (intersection is empty)
+    assert result.allowed_tools == []
+    assert result.denied_tools == base_policy.denied_tools
+    assert result.web_tools_allowed == []
+
+
+def test_merge_with_full_overlap(base_policy: SessionPolicy) -> None:
+    """Test merging when agent tools fully overlap with stage allowed."""
+    agent = AgentSpec(
+        name="overlap-agent",
+        description="Agent with overlapping tools",
+        tools=["Read", "Edit"],  # Subset of base allowed
+        prompt="Test",
+    )
+
+    result = merge_agent_policy(base_policy, agent)
+
+    # Should get intersection: Read, Edit
+    assert set(result.allowed_tools) == {"Read", "Edit"}
+    assert result.web_tools_allowed == []  # WebFetch not in agent tools
+
+
+def test_merge_with_partial_overlap(
+    base_policy: SessionPolicy, agent_with_tools: AgentSpec
+) -> None:
+    """Test merging when agent tools partially overlap with stage allowed."""
+    # Agent has: Read, Edit, WebFetch, Bash
+    # Stage allows: Read, Write, Edit
+    # Stage denies: Bash, WebSearch
+
+    result = merge_agent_policy(base_policy, agent_with_tools)
+
+    # Intersection: Read, Edit (Write not in agent, WebFetch/Bash not in stage allowed)
+    # After removing denied: still Read, Edit (Bash was never in intersection)
+    assert set(result.allowed_tools) == {"Read", "Edit"}
+    assert result.web_tools_allowed == []
+
+
+def test_denied_tools_always_win() -> None:
+    """Test that denied tools are always removed even if in intersection."""
+    # Create policy where a tool is both allowed and denied (edge case)
+    policy = SessionPolicy(
+        stage="test",
+        system_prompt_path=Path("/tmp/test.md"),
+        allowed_tools=["Read", "Write", "Bash"],  # Bash is allowed
+        denied_tools=["Bash"],  # But also denied
+        write_roots=[],
+        permission_mode="restricted",
+        web_tools_allowed=[],
+    )
+
+    agent = AgentSpec(
+        name="bash-agent",
+        description="Agent wanting Bash",
+        tools=["Read", "Bash"],
+        prompt="Test",
+    )
+
+    result = merge_agent_policy(policy, agent)
+
+    # Bash should be removed due to deny list
+    assert "Bash" not in result.allowed_tools
+    assert set(result.allowed_tools) == {"Read"}
+
+
+def test_web_tools_filtered_correctly() -> None:
+    """Test that web_tools_allowed is filtered based on final allowed tools."""
+    # Modify base policy to have WebFetch in allowed
+    policy = SessionPolicy(
+        stage="test",
+        system_prompt_path=Path("/tmp/test.md"),
+        allowed_tools=["Read", "WebFetch", "WebSearch"],
+        denied_tools=[],
+        write_roots=[],
+        permission_mode="restricted",
+        web_tools_allowed=["WebFetch", "WebSearch"],
+    )
+
+    agent = AgentSpec(
+        name="web-agent",
+        description="Agent with limited web",
+        tools=["Read", "WebFetch"],  # Only wants WebFetch, not WebSearch
+        prompt="Test",
+    )
+
+    result = merge_agent_policy(policy, agent)
+
+    # Only WebFetch should remain in web_tools_allowed
+    assert set(result.allowed_tools) == {"Read", "WebFetch"}
+    assert result.web_tools_allowed == ["WebFetch"]  # WebSearch filtered out
+
+
+def test_merge_preserves_other_policy_fields(
+    base_policy: SessionPolicy, agent_with_tools: AgentSpec
+) -> None:
+    """Test that merge preserves non-tool fields from base policy."""
+    result = merge_agent_policy(base_policy, agent_with_tools)
+
+    assert result.stage == base_policy.stage
+    assert result.system_prompt_path == base_policy.system_prompt_path
+    assert result.write_roots == base_policy.write_roots
+    assert result.permission_mode == base_policy.permission_mode
+    assert result.denied_tools == base_policy.denied_tools
+
+
+def test_tools_are_sorted_consistently(base_policy: SessionPolicy) -> None:
+    """Test that allowed tools are sorted for consistent output."""
+    agent = AgentSpec(
+        name="unsorted-agent",
+        description="Agent with unsorted tools",
+        tools=["Edit", "Write", "Read"],  # Deliberately unsorted
+        prompt="Test",
+    )
+
+    result = merge_agent_policy(base_policy, agent)
+
+    # Should be sorted alphabetically
+    assert result.allowed_tools == ["Edit", "Read", "Write"]
+
+
+def test_real_stage_policies_with_agents() -> None:
+    """Test merging with actual stage policies from the system."""
+    # Test with clarify stage (read-only)
+    clarify_policy = get_policy("clarify")
+    researcher = AgentSpec(
+        name="researcher",
+        description="Research agent",
+        tools=["Read", "Write", "WebSearch", "WebFetch"],
+        prompt="Research",
+    )
+
+    result = merge_agent_policy(clarify_policy, researcher)
+
+    # Clarify only allows Read, so intersection is just Read
+    # Clarify denies Write, WebSearch, WebFetch
+    assert result.allowed_tools == ["Read"]
+    assert result.web_tools_allowed == []
+
+    # Test with research stage (allows web when enabled)
+    research_policy = get_policy("research")
+    critic = AgentSpec(
+        name="critic",
+        description="Critic agent",
+        tools=["Read"],  # Read-only agent
+        prompt="Critique",
+    )
+
+    result = merge_agent_policy(research_policy, critic)
+
+    # Critic only wants Read, so that's all it gets
+    assert result.allowed_tools == ["Read"]
+    assert result.web_tools_allowed == []
+
+
+def test_edge_case_agent_requests_only_denied_tools() -> None:
+    """Test when agent only requests tools that are denied."""
+    policy = SessionPolicy(
+        stage="test",
+        system_prompt_path=Path("/tmp/test.md"),
+        allowed_tools=["Read", "Write", "Bash"],
+        denied_tools=["Bash"],
+        write_roots=[],
+        permission_mode="restricted",
+        web_tools_allowed=[],
+    )
+
+    agent = AgentSpec(
+        name="denied-only",
+        description="Agent requesting only denied tools",
+        tools=["Bash"],
+        prompt="Test",
+    )
+
+    result = merge_agent_policy(policy, agent)
+
+    # No tools should be allowed
+    assert result.allowed_tools == []
+    assert result.web_tools_allowed == []


### PR DESCRIPTION
## Summary
- Implemented agent invocation and policy merge functionality as specified in ticket AGT-021
- Added support for selecting agents per session with tool policy merging
- Ensures denied tools always win regardless of agent requests

## Changes
- **Policy Merge Logic**: Added `merge_agent_policy()` function that intersects stage allowed tools with agent requested tools, ensuring denied tools are always removed
- **Session Controller**: Enhanced to accept optional agent selection and display final tool permissions
- **Agent Selection UI**: Created new modal widget for agent selection with live preview of final tools
- **Command Palette Integration**: Updated to show agent selector before starting sessions
- **Comprehensive Tests**: Added full test coverage for policy merge logic including edge cases

## Test Plan
- [x] Run linting: `uv run ruff check .` ✅
- [x] Run type checking: `uv run mypy . --strict` ✅
- [x] Validate merge logic with manual tests ✅
- [x] Test UI agent selection flow
- [x] Verify denied tools always remain denied
- [x] Confirm agent selection persists for session

## Screenshots
The implementation adds an agent selection modal that shows:
- Available agents with descriptions
- Agent requested tools
- Final allowed tools after merge
- Clear indication when tools are denied

## Requirements Met
✅ Agent specs loaded from package at app init
✅ Merge logic: `final_allowed = intersection(stage_allowed, agent_requested) - denied`
✅ UI exposes agent selection and shows final tool set
✅ Unit tests cover all edge cases
✅ Denied tools remain denied regardless of agent request