### PR TITLE
fix: handle fenced code blocks in markdown extraction (MD-015)

### DIFF
--- a/app/files/markdown.py
+++ b/app/files/markdown.py
@@ -50,6 +50,7 @@ def extract_section_paragraph(md: str, header: str = "## Core Concept") -> str |
     lines = md.split("\n")
     header_found = False
     content_lines: list[str] = []
+    in_code_fence = False
 
     for _i, line in enumerate(lines):
         stripped = line.strip()
@@ -66,6 +67,19 @@ def extract_section_paragraph(md: str, header: str = "## Core Concept") -> str |
             continue
 
         # We've found the header, now collect content
+        # Check for code fence markers (``` or ~~~)
+        if stripped.startswith(("```", "~~~")):
+            # If we already have prose content, stop extraction before the fence
+            if content_lines:
+                break
+            # Otherwise, toggle the code fence flag to skip the code block
+            in_code_fence = not in_code_fence
+            continue
+
+        # Skip lines inside code fences
+        if in_code_fence:
+            continue
+
         # Check if we've hit another header of same or higher level
         if stripped.startswith("#"):
             current_level = len(stripped) - len(stripped.lstrip("#"))

--- a/tests/test_markdown_extract.py
+++ b/tests/test_markdown_extract.py
@@ -295,3 +295,88 @@ Default header extraction test.
     # Should use "## Core Concept" by default
     result = extract_section_paragraph(md)
     assert result == "Default header extraction test."
+
+
+def test_extract_code_block_first_no_prose() -> None:
+    """Test when code block is first content with no prose."""
+    md = """
+## Core Concept
+
+```python
+def example():
+    # This is inside the code block
+    return 42
+```
+
+This text comes after the code block.
+
+## Next Section
+"""
+    result = extract_section_paragraph(md, "## Core Concept")
+    assert result == "This text comes after the code block."
+    assert "def example" not in result
+    assert "return 42" not in result
+
+
+def test_extract_code_block_with_tilde_fences() -> None:
+    """Test code blocks with tilde fences."""
+    md = """
+## Core Concept
+
+Some prose content here.
+
+~~~javascript
+console.log("Hello");
+console.log("World");
+~~~
+
+More text after code.
+
+## Next Section
+"""
+    result = extract_section_paragraph(md, "## Core Concept")
+    assert result == "Some prose content here."
+    assert "console.log" not in result
+    assert "Hello" not in result
+
+
+def test_extract_nested_code_blocks() -> None:
+    """Test multiple code blocks in sequence."""
+    md = """
+## Core Concept
+
+```python
+# First code block
+x = 1
+```
+
+```javascript
+// Second code block
+let y = 2;
+```
+
+This is the actual prose content.
+
+## Next Section
+"""
+    result = extract_section_paragraph(md, "## Core Concept")
+    assert result == "This is the actual prose content."
+    assert "x = 1" not in result
+    assert "let y = 2" not in result
+
+
+def test_extract_code_block_no_blank_before() -> None:
+    """Test code block immediately after prose with no blank line."""
+    md = """
+## Core Concept
+This is the prose content.
+```python
+def ignored():
+    pass
+```
+This should not be included.
+"""
+    result = extract_section_paragraph(md, "## Core Concept")
+    assert result == "This is the prose content."
+    assert "def ignored" not in result
+    assert "This should not be included" not in result


### PR DESCRIPTION
## Summary
- Fixed markdown extraction to properly handle fenced code blocks
- Stops extraction when encountering code fences after prose content
- Skips code blocks that appear before prose paragraphs

## Test plan
- [x] All existing tests pass (19 tests in test_markdown_extract.py)
- [x] Verified edge cases with manual testing
- [x] Full validation suite passes (ruff, mypy, pytest)