### PR TITLE
fix: guard os.O_DIRECTORY for cross-platform compatibility (P0-A)

### DIFF
--- a/app/files/atomic.py
+++ b/app/files/atomic.py
@@ -53,7 +53,7 @@ def atomic_write_text(path: Path | str, text: str) -> None:
 
         # Fsync parent directory for durability (best-effort)
         try:
-            dfd = os.open(file_path.parent, os.O_DIRECTORY)
+            dfd = os.open(file_path.parent, getattr(os, "O_DIRECTORY", 0))
             try:
                 os.fsync(dfd)
             finally:

--- a/app/files/diff.py
+++ b/app/files/diff.py
@@ -267,7 +267,7 @@ def apply_patches(patches: list[tuple[Path | str, str, str]]) -> list[Patch]:
             # Fsync each parent directory once
             for parent_dir in parent_dirs:
                 try:
-                    dfd = os.open(parent_dir, os.O_DIRECTORY)
+                    dfd = os.open(parent_dir, getattr(os, "O_DIRECTORY", 0))
                     try:
                         os.fsync(dfd)
                     finally:

--- a/app/permissions/hooks_lib/io.py
+++ b/app/permissions/hooks_lib/io.py
@@ -51,7 +51,7 @@ def atomic_replace_text(path: Path, text: str) -> None:
 
         # Fsync parent directory for durability (best-effort)
         try:
-            dfd = os.open(path.parent, os.O_DIRECTORY)
+            dfd = os.open(path.parent, getattr(os, "O_DIRECTORY", 0))
             try:
                 os.fsync(dfd)
             finally:


### PR DESCRIPTION
## Summary
- Fixed AttributeError on Windows where `os.O_DIRECTORY` doesn't exist
- Replaced direct usage with `getattr(os, 'O_DIRECTORY', 0)` in 3 files
- Maintains directory fsync on Unix while gracefully handling Windows

## Changes
Modified three files that were attempting to fsync parent directories:
- `app/files/atomic.py:56` - in `atomic_write_text()`
- `app/permissions/hooks_lib/io.py:54` - in `atomic_replace_text()`
- `app/files/diff.py:270` - in `apply_patches()`

## Testing
- ✅ All 310 tests pass
- ✅ Lint and typecheck clean
- ✅ Code properly formatted

The fix ensures the code runs without AttributeError on Windows while preserving the directory fsync functionality on platforms that support it.