### PR TITLE
Fix: Add OptionList selection handling to CommandPalette

### DIFF
--- a/app/tui/widgets/command_palette.py
+++ b/app/tui/widgets/command_palette.py
@@ -77,6 +77,16 @@ class CommandPalette(Container):
         self.app.run_worker(self.execute_command(command))
         self.hide()
 
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        """Handle option selection from the list."""
+        # Extract command from the option text (format: "command: description")
+        option_text = str(event.option.prompt)
+        if ":" in option_text:
+            command = option_text.split(":")[0].strip().lower()
+            # Run the async command execution
+            self.app.run_worker(self.execute_command(command))
+            self.hide()
+
     async def execute_command(self, command: str) -> None:
         """Execute the selected command."""
         from textual import log

--- a/tests/test_command_palette_research.py
+++ b/tests/test_command_palette_research.py
@@ -41,6 +41,98 @@ def test_research_import_creates_correct_path() -> None:
 
 
 @pytest.mark.asyncio
+async def test_on_option_list_option_selected() -> None:
+    """Test that selecting an option from the list executes the command."""
+    from textual.widgets import OptionList
+
+    palette = CommandPalette()
+    # Use Mock() instead of direct assignment to avoid method-assign error
+    palette.hide = Mock()  # type: ignore[method-assign]
+
+    # Mock OptionList.OptionSelected event
+    event = MagicMock(spec=OptionList.OptionSelected)
+    # Create a mock option with prompt attribute
+    mock_option = MagicMock()
+    mock_option.prompt = "clarify: Enter clarify stage for current project"
+    event.option = mock_option
+
+    # Track the coroutine to clean it up
+    created_coro: Any | None = None
+
+    def track_coro(coro: Any, **_kwargs: Any) -> MagicMock:
+        nonlocal created_coro
+        created_coro = coro
+        # Return a mock task
+        return MagicMock()
+
+    # Mock app.run_worker to track the coroutine
+    mock_app = MagicMock()
+    mock_app.run_worker = MagicMock(side_effect=track_coro)
+
+    with patch.object(CommandPalette, "app", new=mock_app):
+        # Trigger the event handler
+        palette.on_option_list_option_selected(event)
+
+        # Verify run_worker was called (it schedules execute_command)
+        mock_app.run_worker.assert_called_once()
+
+        # Verify palette was hidden
+        palette.hide.assert_called_once()
+
+        # Clean up the coroutine
+        if created_coro:
+            # Close the coroutine to prevent warning
+            created_coro.close()
+
+
+def test_on_option_list_option_selected_parses_command() -> None:
+    """Test that option selection correctly parses the command from option text."""
+    from textual.widgets import OptionList
+
+    palette = CommandPalette()
+    palette.hide = Mock()  # type: ignore[method-assign]
+
+    # Mock OptionList.OptionSelected event with different command formats
+    event = MagicMock(spec=OptionList.OptionSelected)
+    mock_option = MagicMock()
+    mock_option.prompt = "research import: Import research findings"
+    event.option = mock_option
+
+    # Track the coroutine to clean it up
+    created_coro: Any | None = None
+
+    def track_coro(coro: Any, **_kwargs: Any) -> MagicMock:
+        nonlocal created_coro
+        created_coro = coro
+        return MagicMock()
+
+    # Mock app.run_worker to track the coroutine
+    mock_app = MagicMock()
+    mock_app.run_worker = MagicMock(side_effect=track_coro)
+
+    # Mock execute_command to verify it gets called with correct command
+    with patch.object(palette, "execute_command") as mock_execute:
+        mock_execute.return_value = MagicMock()  # Return a mock coroutine
+
+        with patch.object(CommandPalette, "app", new=mock_app):
+            # Trigger the event handler
+            palette.on_option_list_option_selected(event)
+
+            # Verify execute_command was called with the correct command
+            mock_execute.assert_called_once_with("research import")
+
+            # Verify run_worker was called
+            mock_app.run_worker.assert_called_once()
+
+            # Verify palette was hidden
+            palette.hide.assert_called_once()
+
+            # Clean up the coroutine if one was created
+            if created_coro and hasattr(created_coro, "close"):
+                created_coro.close()
+
+
+@pytest.mark.asyncio
 async def test_on_input_submitted_calls_hide() -> None:
     """Test that input submission hides the palette."""
 


### PR DESCRIPTION
## Summary
- Fixes OptionList selection in CommandPalette widget
- Users can now click/select commands from the dropdown list
- Previously only keyboard input submission worked

## Problem
The OptionList in CommandPalette displayed available commands but didn't respond to selection events. Only the Input field submission was functional, making the dropdown list essentially non-interactive.

## Solution
Added an `on_option_list_option_selected` event handler that:
- Extracts the command name from the selected option text (format: "command: description")
- Executes the command directly via `execute_command()`
- Hides the palette after execution

## Changes
- **app/tui/widgets/command_palette.py**: Added `on_option_list_option_selected` handler (lines 80-88)
- **tests/test_command_palette_research.py**: Added comprehensive test coverage for OptionList selection

## Test Plan
✅ All tests passing (315 tests)
✅ Ruff linting and formatting validated
✅ Mypy type checking passed (strict mode)
✅ Manual testing: Commands can now be selected from the OptionList