### PR TITLE
feat: remove legacy welcome banner from SessionViewer (C3)

### DIFF
--- a/app/tui/widgets/session_viewer.py
+++ b/app/tui/widgets/session_viewer.py
@@ -18,16 +18,6 @@ class SessionViewer(RichLog):
         """Initialize the session viewer."""
         super().__init__(id="session-viewer", wrap=True, highlight=True, markup=True)
 
-    def on_mount(self) -> None:
-        """Display welcome message on mount."""
-        self.write("[bold cyan]Welcome to Brainstorm Buddy[/bold cyan]\n")
-        self.write("\nA terminal-first brainstorming app that guides you through:\n")
-        self.write("• [yellow]Capture[/yellow] → [yellow]Clarify[/yellow] → ")
-        self.write("[yellow]Kernel[/yellow] → [yellow]Outline[/yellow] → ")
-        self.write("[yellow]Research[/yellow] → [yellow]Synthesis[/yellow] → ")
-        self.write("[yellow]Export[/yellow]\n")
-        self.write("\n[dim]Press ':' to open the command palette[/dim]")
-
     def write(
         self,
         content: object,


### PR DESCRIPTION
## Summary
- Removed the `on_mount()` method from SessionViewer that displayed the welcome message
- SessionViewer now starts blank/neutral, aligning with the wizard narrative flow
- Eliminates contradictory messaging for new users

## Ticket
C3 - SessionViewer starts neutral (remove legacy banner)

## Changes
- Deleted `on_mount` method and welcome banner strings from `app/tui/widgets/session_viewer.py`

## Acceptance Criteria
✅ Viewer is blank on startup
✅ No welcome message appears  
✅ CI grep confirms "Welcome to Brainstorm Buddy" does not exist in repo code

## Test Plan
- [x] Launch app - verify SessionViewer is empty
- [x] Run grep to confirm welcome message removed from code
- [x] All lint, typecheck, and tests pass