### PR TITLE
feat: Panel updates for AppState integration (C1, C2, D2, E2)

### DIFF
--- a/app/tui/views/new_project_wizard.py
+++ b/app/tui/views/new_project_wizard.py
@@ -432,12 +432,14 @@ class NewProjectWizard(Screen[bool]):
     def action_focus_next(self) -> None:
         """Focus the next input field."""
         import contextlib
+
         with contextlib.suppress(Exception):
             self.screen.focus_next()
 
     def action_focus_previous(self) -> None:
         """Focus the previous input field."""
         import contextlib
+
         with contextlib.suppress(Exception):
             self.screen.focus_previous()
 
@@ -504,11 +506,11 @@ stage: kernel
 ## Core Concept
 {first_sentence.strip()}.
 
-{self.braindump[:500] if len(self.braindump) > len(first_sentence) else ''}
+{self.braindump[:500] if len(self.braindump) > len(first_sentence) else ""}
 
 ## Key Questions
 Based on your clarifications:
-{chr(10).join('- ' + point for point in key_points) if key_points else self.answers[:500]}
+{chr(10).join("- " + point for point in key_points) if key_points else self.answers[:500]}
 
 ## Success Criteria
 - Complete implementation of described functionality

--- a/app/tui/views/welcome.py
+++ b/app/tui/views/welcome.py
@@ -103,8 +103,7 @@ class WelcomeScreen(Screen[None]):
 
             item = ListItem(
                 Static(
-                    f"[bold]{project['title']}[/bold] ({project['slug']})\n"
-                    f"[dim]{description}[/dim]"
+                    f"[bold]{project['title']}[/bold] ({project['slug']})\n[dim]{description}[/dim]"
                 ),
                 id=f"project-{project['slug']}",
             )

--- a/app/tui/widgets/context_panel.py
+++ b/app/tui/widgets/context_panel.py
@@ -1,7 +1,13 @@
 """Context panel widget for displaying relevant cards and information."""
 
+from collections.abc import Callable
+
 from textual.containers import VerticalScroll
 from textual.widgets import Static
+
+from app.core.interfaces import Reason, Stage
+from app.core.state import get_app_state
+from app.files.project_meta import ProjectMeta
 
 
 class ContextPanel(VerticalScroll):
@@ -23,27 +29,133 @@ class ContextPanel(VerticalScroll):
     }
     """
 
+    # Stage to next action mapping
+    STAGE_NEXT_ACTIONS: dict[Stage, str] = {
+        "capture": "Run :clarify to refine your idea",
+        "clarify": "Run :kernel to distill core concept",
+        "kernel": "Run :workstreams to generate outline",
+        "outline": "Run :research to gather findings",
+        "research": "Run :synthesis to create final doc",
+        "synthesis": "Run :export to generate deliverable",
+    }
+
     def __init__(self) -> None:
         """Initialize the context panel."""
         super().__init__(id="context-panel")
+        self._disposer: Callable[[], None] | None = None
+        self._current_project: str | None = None
+        # Store card references for updates
+        self._stage_card: Static | None = None
+        self._project_card: Static | None = None
+        self._action_card: Static | None = None
 
     def on_mount(self) -> None:
-        """Add placeholder context cards."""
-        self.mount(
-            Static(
-                "[bold]Current Stage[/bold]\n[dim]Capture[/dim]",
-                classes="context-card",
-            )
+        """Subscribe to AppState changes and create initial cards."""
+        # Create initial cards
+        self._stage_card = Static(
+            "[bold]Current Stage[/bold]\n[dim]No project selected[/dim]",
+            classes="context-card",
         )
-        self.mount(
-            Static(
-                "[bold]Project Info[/bold]\n[dim]No project selected[/dim]",
-                classes="context-card",
-            )
+        self._project_card = Static(
+            "[bold]Project Info[/bold]\n[dim]No project selected[/dim]",
+            classes="context-card",
         )
-        self.mount(
-            Static(
-                "[bold]Recent Actions[/bold]\n[dim]• App started\n• Waiting for command[/dim]",
-                classes="context-card",
-            )
+        self._action_card = Static(
+            "[bold]Next Action[/bold]\n[dim]Select a project to begin[/dim]",
+            classes="context-card",
         )
+
+        self.mount(self._stage_card)
+        self.mount(self._project_card)
+        self.mount(self._action_card)
+
+        # Subscribe to project changes
+        app_state = get_app_state()
+        self._disposer = app_state.subscribe(self._on_project_changed)
+
+        # Load initial project if one is active
+        if app_state.active_project:
+            self.update_for_project(app_state.active_project)
+
+    def on_unmount(self) -> None:
+        """Clean up subscription when unmounted."""
+        if self._disposer:
+            self._disposer()
+            self._disposer = None
+
+    def _on_project_changed(
+        self,
+        new_slug: str | None,
+        old_slug: str | None,  # noqa: ARG002
+        reason: Reason,  # noqa: ARG002
+    ) -> None:
+        """Handle project change notifications."""
+        if new_slug != self._current_project:
+            if new_slug:
+                self.update_for_project(new_slug)
+            else:
+                self._show_empty_state()
+
+    def update_for_project(self, slug: str) -> None:
+        """Update context panel for the specified project.
+
+        Args:
+            slug: Project slug to display context for
+        """
+        self._current_project = slug
+
+        # Read project metadata
+        project_data = ProjectMeta.read_project_yaml(slug)
+
+        if not project_data:
+            # Project exists but no metadata
+            if self._project_card:
+                self._project_card.update(
+                    f"[bold]Project Info[/bold]\n"
+                    f"[yellow]Project: {slug}[/yellow]\n"
+                    f"[dim]No project.yaml found[/dim]"
+                )
+            if self._stage_card:
+                self._stage_card.update("[bold]Current Stage[/bold]\n[dim]Unknown[/dim]")
+            if self._action_card:
+                self._action_card.update(
+                    "[bold]Next Action[/bold]\n[dim]Create project.yaml first[/dim]"
+                )
+            return
+
+        # Update project info card
+        title = project_data.get("title", slug)
+        description = project_data.get("description", "No description")
+        if len(description) > 100:
+            description = description[:97] + "..."
+
+        if self._project_card:
+            self._project_card.update(
+                f"[bold]Project Info[/bold]\n[cyan]{title}[/cyan]\n[dim]{description}[/dim]"
+            )
+
+        # Update stage card
+        stage = project_data.get("stage", "capture")
+        stage_display = stage.title() if isinstance(stage, str) else "Unknown"
+
+        if self._stage_card:
+            self._stage_card.update(f"[bold]Current Stage[/bold]\n[green]{stage_display}[/green]")
+
+        # Update next action card
+        next_action = self.STAGE_NEXT_ACTIONS.get(stage, "Review project status")
+
+        if self._action_card:
+            self._action_card.update(f"[bold]Next Action[/bold]\n[yellow]{next_action}[/yellow]")
+
+    def _show_empty_state(self) -> None:
+        """Show empty state when no project is selected."""
+        self._current_project = None
+
+        if self._stage_card:
+            self._stage_card.update("[bold]Current Stage[/bold]\n[dim]No project selected[/dim]")
+        if self._project_card:
+            self._project_card.update("[bold]Project Info[/bold]\n[dim]No project selected[/dim]")
+        if self._action_card:
+            self._action_card.update(
+                "[bold]Next Action[/bold]\n[dim]Select a project to begin[/dim]"
+            )

--- a/app/tui/widgets/file_tree.py
+++ b/app/tui/widgets/file_tree.py
@@ -1,6 +1,13 @@
 """File tree widget for project navigation."""
 
+from collections.abc import Callable
+from pathlib import Path
+
 from textual.widgets import Tree
+
+from app.core.interfaces import Reason
+from app.core.state import get_app_state
+from app.files.project_meta import ProjectMeta
 
 
 class FileTree(Tree[str]):
@@ -15,26 +22,109 @@ class FileTree(Tree[str]):
     """
 
     def __init__(self) -> None:
-        """Initialize the file tree with placeholder content."""
+        """Initialize the file tree."""
         super().__init__("Projects", id="file-tree")
+        self._disposer: Callable[[], None] | None = None
+        self._current_project: str | None = None
 
     def on_mount(self) -> None:
-        """Populate the tree with placeholder project structure."""
-        root = self.root
-        root.expand()
+        """Subscribe to AppState changes when mounted."""
+        app_state = get_app_state()
 
-        # Add placeholder project structure
-        project1 = root.add("📁 example-project", expand=True)
-        project1.add_leaf("📄 kernel.md")
-        project1.add_leaf("📄 outline.md")
-        project1.add_leaf("📄 project.yaml")
+        # Subscribe to project changes
+        self._disposer = app_state.subscribe(self._on_project_changed)
 
-        elements = project1.add("📁 elements", expand=True)
-        elements.add_leaf("📄 workstream-1.md")
-        elements.add_leaf("📄 workstream-2.md")
+        # Load initial project if one is active
+        if app_state.active_project:
+            self.refresh_tree(app_state.active_project)
 
-        research = project1.add("📁 research", expand=True)
-        research.add_leaf("📄 findings.md")
+    def on_unmount(self) -> None:
+        """Clean up subscription when unmounted."""
+        if self._disposer:
+            self._disposer()
+            self._disposer = None
 
-        exports = project1.add("📁 exports", expand=True)
-        exports.add_leaf("📄 synthesis.md")
+    def _on_project_changed(
+        self,
+        new_slug: str | None,
+        old_slug: str | None,  # noqa: ARG002
+        reason: Reason,  # noqa: ARG002
+    ) -> None:
+        """Handle project change notifications."""
+        if new_slug != self._current_project:
+            if new_slug:
+                self.refresh_tree(new_slug)
+            else:
+                self._show_empty_state()
+
+    def refresh_tree(self, slug: str) -> None:
+        """Refresh the tree with actual project files.
+
+        Args:
+            slug: Project slug to display files for
+        """
+        self._current_project = slug
+
+        # Clear existing tree
+        self.root.remove_children()
+
+        # Update root label
+        project_data = ProjectMeta.read_project_yaml(slug)
+        if project_data:
+            project_title = project_data.get("title", slug)
+            self.root.label = f"📁 {project_title}"
+        else:
+            self.root.label = f"📁 {slug}"
+
+        self.root.expand()
+
+        # Build tree from actual files
+        project_path = Path("projects") / slug
+
+        if not project_path.exists():
+            self._show_empty_state()
+            return
+
+        # Known file structure
+        files_to_check = [
+            ("kernel.md", "📄 kernel.md"),
+            ("outline.md", "📄 outline.md"),
+            ("project.yaml", "⚙️ project.yaml"),
+        ]
+
+        # Add top-level files
+        for filename, display_name in files_to_check:
+            file_path = project_path / filename
+            if file_path.exists():
+                self.root.add_leaf(display_name)
+
+        # Add directories if they exist and have content
+        dirs_to_check = [
+            ("elements", "📁 elements"),
+            ("research", "📁 research"),
+            ("exports", "📁 exports"),
+        ]
+
+        for dirname, display_name in dirs_to_check:
+            dir_path = project_path / dirname
+            if dir_path.exists() and dir_path.is_dir():
+                # Check if directory has any files
+                has_files = any(dir_path.iterdir())
+                if has_files:
+                    dir_node = self.root.add(display_name, expand=False)
+                    # Add files in the directory
+                    for file_path in sorted(dir_path.iterdir()):
+                        if file_path.is_file():
+                            file_icon = "📄" if file_path.suffix == ".md" else "📋"
+                            dir_node.add_leaf(f"{file_icon} {file_path.name}")
+
+        # If no files found, show empty state
+        if not self.root.children:
+            self.root.add_leaf("[dim]No files yet[/dim]")
+
+    def _show_empty_state(self) -> None:
+        """Show empty state when no project is selected."""
+        self._current_project = None
+        self.root.remove_children()
+        self.root.label = "Projects"
+        self.root.add_leaf("[dim]No project selected[/dim]")

--- a/tests/test_panel_updates.py
+++ b/tests/test_panel_updates.py
@@ -1,0 +1,354 @@
+"""Integration tests for panel updates with AppState."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from textual.widgets import Static
+
+from app.core.state import get_app_state
+from app.files.project_meta import ProjectMeta
+from app.tui.widgets.context_panel import ContextPanel
+from app.tui.widgets.file_tree import FileTree
+
+
+@pytest.fixture
+def reset_app_state():
+    """Reset AppState singleton for testing."""
+    # Clear the singleton instance
+    import app.core.state
+
+    app.core.state._instance = None
+    yield
+    # Clear again after test
+    app.core.state._instance = None
+
+
+@pytest.fixture
+def sample_project(tmp_path: Path) -> dict[str, str]:
+    """Create a sample project for testing."""
+    # Create project directory
+    project_dir = tmp_path / "projects" / "test-project"
+    project_dir.mkdir(parents=True)
+
+    # Create project.yaml
+    project_data = {
+        "slug": "test-project",
+        "title": "Test Project",
+        "created": "2024-01-01T00:00:00",
+        "stage": "kernel",
+        "description": "A test project for panel updates",
+        "tags": ["test", "integration"],
+        "metadata": {"version": "1.0.0", "format": "brainstormbuddy-project"},
+    }
+
+    # Change to tmp_path for project creation
+    import os
+
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        ProjectMeta.write_project_yaml("test-project", project_data)
+
+        # Create some files
+        (project_dir / "kernel.md").write_text("# Kernel\nTest kernel content")
+        (project_dir / "outline.md").write_text("# Outline\nTest outline")
+
+        # Create elements directory with a file
+        elements_dir = project_dir / "elements"
+        elements_dir.mkdir()
+        (elements_dir / "workstream-1.md").write_text("# Workstream 1")
+
+        # Create empty research directory
+        (project_dir / "research").mkdir()
+
+        return project_data
+    finally:
+        os.chdir(original_cwd)
+
+
+class TestFileTreeUpdates:
+    """Test FileTree widget updates with AppState."""
+
+    def test_file_tree_subscribes_to_appstate(self, reset_app_state, tmp_path):  # noqa: ARG002
+        """Test that FileTree subscribes to AppState on mount."""
+        # Create FileTree
+        tree = FileTree()
+
+        # Mock the refresh_tree method
+        tree.refresh_tree = Mock()
+
+        # Simulate mount
+        tree.on_mount()
+
+        # Verify disposer was created
+        assert tree._disposer is not None
+
+        # Change project
+        app_state = get_app_state()
+        app_state.set_active_project("new-project")
+
+        # Verify refresh was called
+        tree.refresh_tree.assert_called_with("new-project")
+
+        # Clean up
+        tree.on_unmount()
+        assert tree._disposer is None
+
+    def test_file_tree_shows_real_files(self, reset_app_state, sample_project, tmp_path):  # noqa: ARG002
+        """Test that FileTree shows actual project files."""
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            tree = FileTree()
+
+            # Refresh with test project
+            tree.refresh_tree("test-project")
+
+            # Check that project title is set
+            assert "Test Project" in tree.root.label
+
+            # Check that files are listed (would need to traverse tree.root.children)
+            assert tree._current_project == "test-project"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_file_tree_empty_state(self, reset_app_state):  # noqa: ARG002
+        """Test FileTree shows empty state when no project."""
+        tree = FileTree()
+        tree._show_empty_state()
+
+        assert tree._current_project is None
+        assert tree.root.label == "Projects"
+
+
+class TestContextPanelUpdates:
+    """Test ContextPanel widget updates with AppState."""
+
+    def test_context_panel_subscribes_to_appstate(self, reset_app_state):  # noqa: ARG002
+        """Test that ContextPanel subscribes to AppState on mount."""
+        panel = ContextPanel()
+
+        # Create mock cards
+        panel._stage_card = Mock(spec=Static)
+        panel._project_card = Mock(spec=Static)
+        panel._action_card = Mock(spec=Static)
+
+        # Mock update_for_project
+        panel.update_for_project = Mock()
+
+        # Simulate mount
+        panel.on_mount()
+
+        # Verify disposer was created
+        assert panel._disposer is not None
+
+        # Change project
+        app_state = get_app_state()
+        app_state.set_active_project("test-project")
+
+        # Verify update was called
+        panel.update_for_project.assert_called_with("test-project")
+
+        # Clean up
+        panel.on_unmount()
+        assert panel._disposer is None
+
+    def test_context_panel_stage_mapping(self):
+        """Test that ContextPanel has correct stage to action mapping."""
+        panel = ContextPanel()
+
+        # Check all stages are mapped
+        expected_stages = ["capture", "clarify", "kernel", "outline", "research", "synthesis"]
+        for stage in expected_stages:
+            assert stage in panel.STAGE_NEXT_ACTIONS
+            assert isinstance(panel.STAGE_NEXT_ACTIONS[stage], str)
+
+        # Check specific mappings
+        assert "clarify" in panel.STAGE_NEXT_ACTIONS["capture"]
+        assert "kernel" in panel.STAGE_NEXT_ACTIONS["clarify"]
+        assert "workstreams" in panel.STAGE_NEXT_ACTIONS["kernel"]
+        assert "research" in panel.STAGE_NEXT_ACTIONS["outline"]
+        assert "synthesis" in panel.STAGE_NEXT_ACTIONS["research"]
+        assert "export" in panel.STAGE_NEXT_ACTIONS["synthesis"]
+
+    def test_context_panel_update_for_project(self, reset_app_state, sample_project, tmp_path):  # noqa: ARG002
+        """Test ContextPanel updates correctly for a project."""
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            panel = ContextPanel()
+
+            # Create mock cards
+            panel._stage_card = Mock(spec=Static)
+            panel._project_card = Mock(spec=Static)
+            panel._action_card = Mock(spec=Static)
+
+            # Update for test project
+            panel.update_for_project("test-project")
+
+            # Verify cards were updated
+            panel._project_card.update.assert_called()
+            panel._stage_card.update.assert_called()
+            panel._action_card.update.assert_called()
+
+            # Check that kernel stage shows correct next action
+            action_call_args = panel._action_card.update.call_args[0][0]
+            assert "workstreams" in action_call_args.lower()
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestPanelSynchronization:
+    """Test synchronization between panels on project switch."""
+
+    @pytest.mark.asyncio
+    async def test_rapid_project_switching(self, reset_app_state, tmp_path):  # noqa: ARG002
+        """Test panels handle rapid project switching without stale state."""
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            # Create multiple projects
+            for i in range(3):
+                project_dir = tmp_path / "projects" / f"project-{i}"
+                project_dir.mkdir(parents=True)
+                ProjectMeta.write_project_yaml(
+                    f"project-{i}",
+                    {
+                        "slug": f"project-{i}",
+                        "title": f"Project {i}",
+                        "created": "2024-01-01T00:00:00",
+                        "stage": "capture",
+                        "description": f"Project {i} description",
+                        "tags": [],
+                        "metadata": {"version": "1.0.0", "format": "brainstormbuddy-project"},
+                    },
+                )
+
+            # Create panels
+            tree = FileTree()
+            panel = ContextPanel()
+
+            # Mock update methods
+            tree.refresh_tree = Mock()
+            panel.update_for_project = Mock()
+
+            # Simulate mount
+            tree.on_mount()
+            panel.on_mount()
+
+            app_state = get_app_state()
+
+            # Rapid switching
+            for _ in range(2):
+                for i in range(3):
+                    app_state.set_active_project(f"project-{i}")
+                    await asyncio.sleep(0.01)  # Small delay
+
+            # Final project should be project-2
+            assert app_state.active_project == "project-2"
+
+            # Both panels should have been called with project-2 as the last call
+            tree.refresh_tree.assert_called_with("project-2")
+            panel.update_for_project.assert_called_with("project-2")
+
+            # Clean up
+            tree.on_unmount()
+            panel.on_unmount()
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestResearchDBPath:
+    """Test research database path resolution."""
+
+    def test_get_db_path_creates_directory(self, tmp_path):
+        """Test that get_db_path creates research directory if missing."""
+        import os
+
+        from app.tui.views.research import get_db_path
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            # Create projects directory but not research
+            (tmp_path / "projects" / "test-proj").mkdir(parents=True)
+
+            # Get DB path
+            db_path = get_db_path("test-proj")
+
+            # Verify path and directory creation
+            assert db_path == tmp_path / "projects" / "test-proj" / "research" / "findings.db"
+            assert db_path.parent.exists()
+            assert db_path.parent.name == "research"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_research_modal_uses_active_project(self, reset_app_state, tmp_path):  # noqa: ARG002
+        """Test ResearchImportModal uses active project for DB path."""
+        import os
+
+        from app.tui.views.research import ResearchImportModal
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            # Set active project
+            app_state = get_app_state()
+            app_state.set_active_project("my-project")
+
+            # Create modal without explicit db_path
+            modal = ResearchImportModal()
+
+            # Verify it uses active project path
+            assert "my-project" in str(modal.db_path)
+            assert "research" in str(modal.db_path)
+            assert modal.db_path.name == "findings.db"
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestCommandPaletteIntegration:
+    """Test command palette uses active project."""
+
+    @pytest.mark.asyncio
+    async def test_commands_require_active_project(self, reset_app_state):  # noqa: ARG002
+        """Test that commands check for active project."""
+        from app.tui.widgets.command_palette import CommandPalette
+        from app.tui.widgets.session_viewer import SessionViewer
+
+        palette = CommandPalette()
+
+        # Mock app and viewer
+        viewer = Mock(spec=SessionViewer)
+        palette.app = Mock()
+        palette.app.query_one = Mock(return_value=viewer)
+
+        # Commands that require a project
+        project_commands = ["kernel", "generate workstreams", "research import", "synthesis"]
+
+        # Test without active project
+        app_state = get_app_state()
+        app_state.set_active_project(None)
+
+        for command in project_commands:
+            await palette.execute_command(command)
+
+            # Should write warning message
+            viewer.write.assert_called()
+            call_args = viewer.write.call_args[0][0]
+            assert "No active project" in call_args or "select a project" in call_args.lower()
+            viewer.write.reset_mock()

--- a/tests/test_research_import_integration.py
+++ b/tests/test_research_import_integration.py
@@ -12,10 +12,28 @@ from app.tui.views.research import ResearchImportModal
 from app.tui.widgets.command_palette import CommandPalette
 
 
+@pytest.fixture
+def reset_app_state():
+    """Reset AppState singleton for testing."""
+    # Clear the singleton instance
+    import app.core.state
+
+    app.core.state._instance = None
+    yield
+    # Clear again after test
+    app.core.state._instance = None
+
+
 @pytest.mark.asyncio
-async def test_research_import_command_execution(tmp_path: Path) -> None:
+async def test_research_import_command_execution(tmp_path: Path, reset_app_state) -> None:  # noqa: ARG001
     """Test that research import command can be executed."""
+    from app.core.state import get_app_state
+
     palette = CommandPalette()
+
+    # Set active project
+    app_state = get_app_state()
+    app_state.set_active_project("default")
 
     # Create the project directory
     mock_project_path = tmp_path / "projects" / "default"
@@ -74,7 +92,7 @@ async def test_research_modal_compose_elements() -> None:
 
     # Test that the modal has expected default values
     assert modal.workstream == "research"
-    assert str(modal.db_path).endswith("research.db")
+    assert str(modal.db_path).endswith("findings.db")  # Changed from research.db to findings.db
     assert modal.status_message == ""
     assert modal.findings == []
 

--- a/tests/test_research_import_integration.py
+++ b/tests/test_research_import_integration.py
@@ -1,7 +1,7 @@
 """Integration tests for research import functionality."""
 
 import asyncio
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,7 +13,7 @@ from app.tui.widgets.command_palette import CommandPalette
 
 
 @pytest.fixture
-def reset_app_state():
+def reset_app_state() -> Generator[None, None, None]:
     """Reset AppState singleton for testing."""
     # Clear the singleton instance
     import app.core.state
@@ -25,8 +25,11 @@ def reset_app_state():
 
 
 @pytest.mark.asyncio
-async def test_research_import_command_execution(tmp_path: Path, reset_app_state) -> None:  # noqa: ARG001
+async def test_research_import_command_execution(tmp_path: Path, reset_app_state: None) -> None:  # noqa: ARG001
     """Test that research import command can be executed."""
+    # Fixture ensures app state is reset
+    del reset_app_state
+
     from app.core.state import get_app_state
 
     palette = CommandPalette()

--- a/tests/test_welcome_screen.py
+++ b/tests/test_welcome_screen.py
@@ -102,7 +102,7 @@ class TestWelcomeScreen:
                 "title": f"Project {i}",
                 "description": f"Description {i}",
                 "stage": "capture",
-                "created": f"2024-01-0{i+1}T00:00:00",
+                "created": f"2024-01-0{i + 1}T00:00:00",
                 "tags": [],
                 "metadata": {"version": "1.0.0", "format": "brainstormbuddy-project"},
             }


### PR DESCRIPTION
## Summary
- Updated existing panels (FileTree, ContextPanel, CommandPalette, Research) to be context-aware and reactive to project switching
- All panels now subscribe to AppState changes and update automatically when the active project changes
- Research DB now uses dynamic path resolution with WAL mode for better concurrent access

## Changes
### C1: FileTree Widget
- Shows real project files from `projects/{slug}` directory
- Subscribes to AppState changes via disposer pattern
- Lists only existing files/directories (kernel.md, outline.md, project.yaml, elements/, research/, exports/)
- Shows empty state when no project selected

### C2: ContextPanel Widget  
- Displays live project state with current stage
- Shows next action guidance based on stage mapping
- Updates project title and description from project.yaml
- Graceful handling of missing metadata

### D2: Command Palette
- Uses active project from AppState for all project-requiring commands
- Shows warning if no active project when trying to run commands
- Updated: clarify, kernel, generate workstreams, research import, synthesis

### E2: Research DB Path
- Added `get_db_path(slug)` helper function
- Research DB path resolved dynamically based on active project
- Creates research directory if missing
- Enables SQLite WAL mode for better concurrent access

## Test Plan
- [x] Created comprehensive integration tests in `tests/test_panel_updates.py`
- [x] Tests verify panel subscription to AppState
- [x] Tests verify correct updates on project switching
- [x] Tests verify research DB path resolution
- [x] All existing tests pass
- [x] Linting and type checking pass